### PR TITLE
Add GitHub App installation token workflow

### DIFF
--- a/.github/workflows/github-app-installation-token.yml
+++ b/.github/workflows/github-app-installation-token.yml
@@ -1,0 +1,29 @@
+name: Playground for GitHub App Installation Token
+on:
+  workflow_dispatch:
+
+vars:
+  repo-name: tanimon/tanimon
+
+jobs:
+  checkout-another-repo-without-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ vars.REPO_NAME }}
+
+  checkout-another-repo-with-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ vars.REPO_NAME }}
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false


### PR DESCRIPTION
このプルリクエストでは、GitHub App Installation Tokens を試すための新しい GitHub Actions ワークフローを導入します。
このワークフローには、トークンなしでリポジトリをチェックアウトするジョブと GitHub App トークンを使ってリポジトリをチェックアウトするジョブのふたつが含まれます。

新しい GitHub Actions ワークフロー:

- [`.github/workflows/github-app-installation-token.yml`](diffhunk://#diff-67cf2f9fceea3466f9047e14e02a1da04cceca1f92d9c6e8bcfcc4db0e36c0f1R1-R29): 新しいワークフロー "Playground for GitHub App Installation Token" を追加しました。GitHub App トークンを使った場合と使わない場合のリポジトリのチェックアウトをテストする二つのジョブがあります。
