### PR TITLE
Add ref parameter to GitHub App installation token workflow

### DIFF
--- a/.github/workflows/github-app-installation-token.yml
+++ b/.github/workflows/github-app-installation-token.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   repo-name: tanimon/dummy-private-repo
+  ref: main
 
 jobs:
   checkout-another-repo-without-token:
@@ -12,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{ env.repo-name }}
+          ref: ${{ env.ref }}
       - run: cat README.md
 
   checkout-another-repo-with-token:
@@ -25,6 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{ env.repo-name }}
+          ref: ${{ env.ref }}
           token: ${{ steps.app-token.outputs.token }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false


### PR DESCRIPTION
- 実行した際にデフォルトブランチ名が見つからずエラーが発生したので、明示的に checkout 対象ブランチを指定する
  - https://github.com/tanimon/gha-playground/actions/runs/13385440108/job/37381188218
- Specify the branch/ref when checking out the repository
- Add `ref: main` to both jobs in the workflow
