### PR TITLE
Update GitHub App installation token workflow

### DIFF
--- a/.github/workflows/github-app-installation-token.yml
+++ b/.github/workflows/github-app-installation-token.yml
@@ -10,10 +10,11 @@ jobs:
   checkout-another-repo-without-token:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ env.repo-name }}
-          ref: ${{ env.ref }}
+      # - uses: actions/checkout@v4
+      #   with:
+      #     repository: ${{ env.repo-name }}
+      #     ref: ${{ env.ref }}
+      - run: git clone "https://github.com/${{ env.repo-name }}.git"
       - run: cat README.md
 
   checkout-another-repo-with-token:
@@ -24,11 +25,12 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ env.repo-name }}
-          ref: ${{ env.ref }}
-          token: ${{ steps.app-token.outputs.token }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
+      # - uses: actions/checkout@v4
+      #   with:
+      #     repository: ${{ env.repo-name }}
+      #     ref: ${{ env.ref }}
+      #     token: ${{ steps.app-token.outputs.token }}
+      #     # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+      #     persist-credentials: false
+      - run: git clone "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ env.repo-name }}.git"
       - run: cat README.md

--- a/.github/workflows/github-app-installation-token.yml
+++ b/.github/workflows/github-app-installation-token.yml
@@ -10,27 +10,56 @@ jobs:
   checkout-another-repo-without-token:
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v4
-      #   with:
-      #     repository: ${{ env.repo-name }}
-      #     ref: ${{ env.ref }}
-      - run: git clone "https://github.com/${{ env.repo-name }}.git"
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ env.repo-name }}
+          ref: ${{ env.ref }}
+
       - run: cat README.md
 
   checkout-another-repo-with-token:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
+      - name: Generate token with tibdex/github-app-token
+        id: tibdex
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Generate token with actions/create-github-app-token
+        id: gha
+        uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      # - uses: actions/checkout@v4
-      #   with:
-      #     repository: ${{ env.repo-name }}
-      #     ref: ${{ env.ref }}
-      #     token: ${{ steps.app-token.outputs.token }}
-      #     # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-      #     persist-credentials: false
-      - run: git clone "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ env.repo-name }}.git"
+
+      - name: who am i with actions/create-github-app-token?
+        run: gh auth status
+        env:
+          GH_TOKEN: ${{ steps.gha.outputs.token }}
+
+      - name: who am i with tibdex/github-app-token?
+        run: gh auth status
+        env:
+          GH_TOKEN: ${{ steps.tibdex.outputs.token }}
+
+      - name: Checkout with actions/create-github-app-token
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.repo-name }}
+          ref: ${{ env.ref }}
+          token: ${{ steps.gha.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+
+      - name: Checkout with tibdex/github-app-token
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.repo-name }}
+          ref: ${{ env.ref }}
+          token: ${{ steps.tibdex.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+
       - run: cat README.md

--- a/.github/workflows/github-app-installation-token.yml
+++ b/.github/workflows/github-app-installation-token.yml
@@ -10,7 +10,7 @@ jobs:
   checkout-another-repo-without-token:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ env.repo-name }}
           ref: ${{ env.ref }}
@@ -24,7 +24,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ env.repo-name }}
           ref: ${{ env.ref }}

--- a/.github/workflows/github-app-installation-token.yml
+++ b/.github/workflows/github-app-installation-token.yml
@@ -17,7 +17,7 @@ jobs:
 
       - run: cat README.md
 
-  checkout-another-repo-with-token:
+  checkout-another-repo-with-token-created-with-tibdex:
     runs-on: ubuntu-latest
     steps:
       - name: Generate token with tibdex/github-app-token
@@ -27,6 +27,34 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: who am i with tibdex/github-app-token?
+        run: gh auth status
+        env:
+          GH_TOKEN: ${{ steps.tibdex.outputs.token }}
+
+      - name: Checkout with tibdex/github-app-token
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.repo-name }}
+          ref: ${{ env.ref }}
+          token: ${{ steps.tibdex.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+
+      - name: Checkout with actions/create-github-app-token
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.repo-name }}
+          ref: ${{ env.ref }}
+          token: ${{ steps.gha.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+
+      - run: cat README.md
+
+  checkout-another-repo-with-token-created-with-actions:
+    runs-on: ubuntu-latest
+    steps:
       - name: Generate token with actions/create-github-app-token
         id: gha
         uses: actions/create-github-app-token@v1
@@ -39,26 +67,12 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.gha.outputs.token }}
 
-      - name: who am i with tibdex/github-app-token?
-        run: gh auth status
-        env:
-          GH_TOKEN: ${{ steps.tibdex.outputs.token }}
-
       - name: Checkout with actions/create-github-app-token
         uses: actions/checkout@v4
         with:
           repository: ${{ env.repo-name }}
           ref: ${{ env.ref }}
           token: ${{ steps.gha.outputs.token }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
-
-      - name: Checkout with tibdex/github-app-token
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.repo-name }}
-          ref: ${{ env.ref }}
-          token: ${{ steps.tibdex.outputs.token }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
 

--- a/.github/workflows/github-app-installation-token.yml
+++ b/.github/workflows/github-app-installation-token.yml
@@ -41,15 +41,6 @@ jobs:
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
 
-      - name: Checkout with actions/create-github-app-token
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.repo-name }}
-          ref: ${{ env.ref }}
-          token: ${{ steps.gha.outputs.token }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
-
       - run: cat README.md
 
   checkout-another-repo-with-token-created-with-actions:

--- a/create-installation-token.sh
+++ b/create-installation-token.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# This script creates an installation token for a GitHub App.
+#
+# Usage:
+#   ./create-installation-token.sh [--debug] --client-id <client_id> --pem-path <pem_file_path>
+#
+# Example:
+#   ./create-installation-token.sh --client-id 1234567890 --pem-path ./path/to/private-key.pem
+#
+# ref: https://docs.github.com/ja/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#example-using-bash-to-generate-a-jwt
+
+set -o pipefail
+
+debug=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --debug)
+      debug=true
+      shift
+      ;;
+    --client-id)
+      client_id=$2
+      shift 2
+      ;;
+    --pem-path)
+      pem_path=$2
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$debug" = true ]; then
+  set -x
+fi
+
+if [ -z "$client_id" ] || [ -z "$pem_path" ]; then
+  echo "Usage: $0 [--debug] --client-id <client_id> --pem-path <pem_file_path>"
+  exit 1
+fi
+
+pem=$(cat "$pem_path")
+
+now=$(date +%s)
+iat=$((${now} - 60)) # Issues 60 seconds in the past
+exp=$((${now} + 600)) # Expires 10 minutes in the future
+
+b64enc() { openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n'; }
+
+header_json='{
+    "typ":"JWT",
+    "alg":"RS256"
+}'
+# Header encode
+header=$( echo -n "${header_json}" | b64enc )
+
+payload_json="{
+    \"iat\":${iat},
+    \"exp\":${exp},
+    \"iss\":\"${client_id}\"
+}"
+# Payload encode
+payload=$( echo -n "${payload_json}" | b64enc )
+
+# Signature
+header_payload="${header}"."${payload}"
+signature=$(
+    openssl dgst -sha256 -sign <(echo -n "${pem}") \
+    <(echo -n "${header_payload}") | b64enc
+)
+
+# Create JWT
+JWT="${header_payload}"."${signature}"
+
+if [ "$debug" = true ]; then
+  printf '%s\n' "JWT: $JWT"
+fi
+
+GITHUB_API_URL="https://api.github.com"
+GITHUB_REPOSITORY='tanimon/gha-playground'
+
+installation_response="$(curl --location --silent --request GET \
+  --url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/installation" \
+  --header "Accept: application/vnd.github+json" \
+  --header "X-GitHub-Api-Version: 2022-11-28" \
+  --header "Authorization: Bearer ${JWT}" \
+  )"
+
+if [ "$debug" = true ]; then
+  echo "installation_response: ${installation_response}"
+fi
+
+installation_id="$(echo "${installation_response}" | jq -r '.id')"
+
+if [ "$debug" = true ]; then
+  echo "installation_id: ${installation_id}"
+fi
+
+token_response="$(curl --location --silent --request POST \
+  --url "${GITHUB_API_URL}/app/installations/${installation_id}/access_tokens" \
+  --header "Accept: application/vnd.github+json" \
+  --header "X-GitHub-Api-Version: 2022-11-28" \
+  --header "Authorization: Bearer ${JWT}" \
+  )"
+
+if [ "$debug" = true ]; then
+  echo "token_response: ${token_response}"
+fi
+
+token="$(echo "${token_response}" | jq -r '.token')"
+
+echo "${token}"


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflows and the addition of a new script for generating installation tokens for a GitHub App. The most important changes include updating the `actions/checkout` version, adding new job steps for generating tokens using different methods, and introducing a new Bash script for token creation.

Updates to GitHub Actions workflows:

* [`.github/workflows/github-app-installation-token.yml`](diffhunk://#diff-67cf2f9fceea3466f9047e14e02a1da04cceca1f92d9c6e8bcfcc4db0e36c0f1L13-R69): Updated `actions/checkout` from version 3 to version 4.
* [`.github/workflows/github-app-installation-token.yml`](diffhunk://#diff-67cf2f9fceea3466f9047e14e02a1da04cceca1f92d9c6e8bcfcc4db0e36c0f1L13-R69): Added job steps to generate tokens using `tibdex/github-app-token` and `actions/create-github-app-token`, and included steps to authenticate and checkout repositories using these tokens.

New script for generating installation tokens:

* [`create-installation-token.sh`](diffhunk://#diff-5c552fc9dcd69f315cbb0acc7372a32dc521a4ff325ab870bc18c1cca4efb468R1-R117): Added a new Bash script to create an installation token for a GitHub App, including options for debugging and specifying client ID and PEM file path.